### PR TITLE
Add core Prisma database schema and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,3 +423,40 @@ services:
     ports:
       - "6333:6333"
 ```
+
+## Database Setup
+
+This repository uses **PostgreSQL** with **Prisma ORM**. The Prisma schema is in `prisma/schema.prisma` and migrations are stored under `prisma/migrations`.
+
+### Generate Prisma Clients
+
+```
+npm install
+npm run generate
+```
+
+### Apply Migrations
+
+Set the `DATABASE_URL` environment variable and run:
+
+```
+npm run migrate
+```
+
+### Seed Data
+
+```
+npm run seed
+```
+
+### Using Prisma from Python
+
+The Prisma Python client is generated to the `python_client` directory. An example usage is available in `scripts/py_client.py`.
+
+### Database Backup
+
+Run `scripts/backup.sh` to create a `pg_dump` of the current database:
+
+```
+DATABASE_URL=postgresql://user:pass@localhost:5432/dbname ./scripts/backup.sh
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "learn-database",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "generate": "prisma generate",
+    "migrate": "prisma migrate deploy",
+    "seed": "ts-node prisma/seed.ts",
+    "test": "echo 'No tests specified'"
+  },
+  "devDependencies": {
+    "prisma": "^5.14.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.14.0"
+  }
+}

--- a/prisma/migrations/000-init/migration.sql
+++ b/prisma/migrations/000-init/migration.sql
@@ -1,0 +1,31 @@
+-- Migration SQL for initial database schema
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    role TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE courses (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    instructor_id INTEGER NOT NULL REFERENCES users(id)
+);
+
+CREATE TABLE questions (
+    id SERIAL PRIMARY KEY,
+    course_id INTEGER NOT NULL REFERENCES courses(id),
+    content TEXT NOT NULL,
+    type TEXT NOT NULL,
+    metadata JSONB
+);
+
+CREATE TABLE student_responses (
+    id SERIAL PRIMARY KEY,
+    student_id INTEGER NOT NULL REFERENCES users(id),
+    question_id INTEGER NOT NULL REFERENCES questions(id),
+    response TEXT NOT NULL,
+    is_correct BOOLEAN NOT NULL
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,65 @@
+// Prisma schema for Learn database
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator py {
+  provider = "prisma-client-py"
+  output   = "../python_client"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String
+  role      String
+  createdAt DateTime @default(now())
+
+  courses   Course[] @relation("InstructorCourses")
+  responses StudentResponse[]
+
+  @@map("users")
+}
+
+model Course {
+  id           Int     @id @default(autoincrement())
+  name         String
+  description  String
+  instructor   User     @relation("InstructorCourses", fields: [instructorId], references: [id])
+  instructorId Int
+
+  questions    Question[]
+
+  @@map("courses")
+}
+
+model Question {
+  id        Int      @id @default(autoincrement())
+  course    Course   @relation(fields: [courseId], references: [id])
+  courseId  Int
+  content   String
+  type      String
+  metadata  Json?
+
+  responses StudentResponse[]
+
+  @@map("questions")
+}
+
+model StudentResponse {
+  id         Int      @id @default(autoincrement())
+  student    User     @relation(fields: [studentId], references: [id])
+  studentId  Int
+  question   Question @relation(fields: [questionId], references: [id])
+  questionId Int
+  response   String
+  isCorrect  Boolean
+
+  @@map("student_responses")
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,37 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const instructor = await prisma.user.create({
+    data: {
+      email: 'instructor@example.com',
+      name: 'Instructor',
+      role: 'instructor',
+    },
+  })
+
+  const course = await prisma.course.create({
+    data: {
+      name: 'Intro to AI',
+      description: 'Basics of artificial intelligence',
+      instructorId: instructor.id,
+    },
+  })
+
+  await prisma.question.create({
+    data: {
+      courseId: course.id,
+      content: 'What is AI?',
+      type: 'short_answer',
+    },
+  })
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Simple database backup script
+DATE=$(date +"%Y%m%d_%H%M%S")
+pg_dump "$DATABASE_URL" > "backup_$DATE.sql"

--- a/scripts/py_client.py
+++ b/scripts/py_client.py
@@ -1,0 +1,14 @@
+from prisma import Prisma
+import asyncio
+
+async def main() -> None:
+    db = Prisma()
+    await db.connect()
+
+    courses = await db.course.find_many(include={"instructor": True})
+    print(courses)
+
+    await db.disconnect()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/ts-client.ts
+++ b/scripts/ts-client.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function listCourses() {
+  const courses = await prisma.course.findMany({
+    include: { instructor: true }
+  })
+  console.log(courses)
+}
+
+listCourses().finally(async () => {
+  await prisma.$disconnect()
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["prisma/**/*.ts", "scripts/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- set up Prisma schema and initial SQL migration
- add example TypeScript and Python Prisma clients
- provide seed script and simple backup script
- document database setup in README

## Testing
- `npm test`
- `pytest`