### PR TITLE
Add simple JWT auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,3 +423,4 @@ services:
     ports:
       - "6333:6333"
 ```
+\n## Authentication Example\nA minimal Node.js example implementing JWT-based login with role-based access control is located in `backend/` with static pages in `frontend/`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Authentication Backend
+
+Simple Express.js authentication with JWT and role-based access control.
+
+## Setup
+
+```
+npm install
+npm start
+```
+
+## Endpoints
+- `POST /signup` - create a user `{ username, password, role }`
+- `POST /login` - log in `{ username, password }`, returns JWT token
+- `GET /profile` - get logged in user info (requires Authorization header)
+- `GET /instructor` - instructor-only route
+- `GET /student` - student-only route
+
+This is a minimal example and does not persist users between restarts.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcrypt');
+const cookieParser = require('cookie-parser');
+const session = require('express-session');
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+app.use(session({
+  secret: 'change_this_secret',
+  resave: false,
+  saveUninitialized: false,
+  cookie: { secure: false }
+}));
+
+const users = [];
+const SECRET_KEY = 'super_secret_jwt_key';
+
+async function createUser(username, password, role = 'Student') {
+  const hashed = await bcrypt.hash(password, 10);
+  const user = { username, password: hashed, role };
+  users.push(user);
+  return user;
+}
+
+function authenticate(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Token required' });
+  try {
+    const payload = jwt.verify(token, SECRET_KEY);
+    req.user = payload;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+function authorize(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+    next();
+  };
+}
+
+app.post('/signup', async (req, res) => {
+  const { username, password, role } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  const existing = users.find(u => u.username === username);
+  if (existing) {
+    return res.status(400).json({ error: 'User already exists' });
+  }
+  const user = await createUser(username, password, role);
+  res.json({ message: 'User created', user: { username: user.username, role: user.role } });
+});
+
+app.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+  const token = jwt.sign({ username: user.username, role: user.role }, SECRET_KEY, { expiresIn: '1h' });
+  req.session.user = { username: user.username, role: user.role };
+  res.json({ token });
+});
+
+app.get('/profile', authenticate, (req, res) => {
+  res.json({ user: req.user });
+});
+
+app.get('/instructor', authenticate, authorize('Instructor'), (req, res) => {
+  res.json({ message: 'Welcome Instructor' });
+});
+
+app.get('/student', authenticate, authorize('Student'), (req, res) => {
+  res.json({ message: 'Welcome Student' });
+});
+
+app.listen(3000, () => console.log('Server running on port 3000'));

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "bcrypt": "^5.1.0",
+    "cookie-parser": "^1.4.6",
+    "express-session": "^1.17.4"
+  }
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,5 @@
+# Frontend Pages
+
+Simple static pages for login, signup, and viewing the user profile. The pages use the backend API to authenticate users and store the JWT token in `localStorage`.
+
+Serve these files from a static host or configure Express to serve them from the `/` path.

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <label>Username: <input type="text" id="username" /></label><br />
+    <label>Password: <input type="password" id="password" /></label><br />
+    <button type="submit">Login</button>
+  </form>
+  <div id="msg"></div>
+<script>
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const res = await fetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  const data = await res.json();
+  if (data.token) {
+    localStorage.setItem('token', data.token);
+    window.location.href = '/profile.html';
+  } else {
+    document.getElementById('msg').textContent = data.error;
+  }
+});
+</script>
+</body>
+</html>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Profile</title>
+</head>
+<body>
+  <h1>User Profile</h1>
+  <div id="info"></div>
+  <script>
+  async function loadProfile() {
+    const token = localStorage.getItem('token');
+    if (!token) { window.location.href = '/login.html'; return; }
+    const res = await fetch('/profile', {
+      headers: { 'Authorization': 'Bearer ' + token }
+    });
+    const data = await res.json();
+    if (data.user) {
+      document.getElementById('info').textContent = `Username: ${data.user.username} Role: ${data.user.role}`;
+    } else {
+      localStorage.removeItem('token');
+      window.location.href = '/login.html';
+    }
+  }
+  loadProfile();
+  </script>
+</body>
+</html>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Signup</title>
+</head>
+<body>
+  <h1>Signup</h1>
+  <form id="signupForm">
+    <label>Username: <input type="text" id="username" /></label><br />
+    <label>Password: <input type="password" id="password" /></label><br />
+    <label>Role:
+      <select id="role">
+        <option value="Student">Student</option>
+        <option value="Instructor">Instructor</option>
+        <option value="TA">TA</option>
+      </select>
+    </label><br />
+    <button type="submit">Signup</button>
+  </form>
+  <div id="msg"></div>
+<script>
+document.getElementById('signupForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const role = document.getElementById('role').value;
+  const res = await fetch('/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password, role })
+  });
+  const data = await res.json();
+  if (data.message) {
+    window.location.href = '/login.html';
+  } else {
+    document.getElementById('msg').textContent = data.error;
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Express backend with JWT-based auth and role middleware
- create minimal frontend pages for login, signup and profile
- document the backend and update root README

## Testing
- `npm install` *(fails: no internet access)*