### PR TITLE
Add assignment builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,3 +469,7 @@ Run `scripts/backup.sh` to create a `pg_dump` of the current database:
 ```
 DATABASE_URL=postgresql://user:pass@localhost:5432/dbname ./scripts/backup.sh
 ```
+
+## Assignment Builder
+
+Instructors can create and schedule assignments from approved questions using `frontend/assignments.html`. The page provides a simple wizard to configure settings, drag and drop questions, preview the student view and save the assignment to the backend. Assignments are stored in memory by `backend/assignments.js` and exposed through `/assignments` endpoints.

--- a/backend/assignments.js
+++ b/backend/assignments.js
@@ -1,0 +1,37 @@
+// Simple in-memory store for assignments and templates
+let assignments = [];
+let templates = [];
+let nextId = 1;
+
+function scheduleStatusCheck() {
+  setInterval(() => {
+    const now = Date.now();
+    assignments.forEach(a => {
+      if (a.status === 'scheduled' && new Date(a.startDate).getTime() <= now) {
+        a.status = 'open';
+      }
+      if (a.status !== 'completed' && new Date(a.dueDate).getTime() < now) {
+        a.status = 'closed';
+      }
+    });
+  }, 60 * 1000);
+}
+
+scheduleStatusCheck();
+
+function createAssignment(data) {
+  const assignment = { id: nextId++, status: 'draft', ...data };
+  if (assignment.startDate && new Date(assignment.startDate).getTime() > Date.now()) {
+    assignment.status = 'scheduled';
+  } else {
+    assignment.status = 'open';
+  }
+  assignments.push(assignment);
+  return assignment;
+}
+
+module.exports = {
+  assignments,
+  templates,
+  createAssignment,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,11 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
 const cookieParser = require('cookie-parser');
 const session = require('express-session');
+const {
+  assignments,
+  templates,
+  createAssignment,
+} = require('./assignments');
 
 const app = express();
 app.use(express.json());
@@ -80,6 +85,40 @@ app.get('/instructor', authenticate, authorize('Instructor'), (req, res) => {
 
 app.get('/student', authenticate, authorize('Student'), (req, res) => {
   res.json({ message: 'Welcome Student' });
+});
+
+// ----- Assignment Endpoints -----
+app.get('/assignments', authenticate, authorize('Instructor'), (req, res) => {
+  res.json(assignments);
+});
+
+app.post('/assignments', authenticate, authorize('Instructor'), (req, res) => {
+  const data = req.body;
+  if (!data.title || !Array.isArray(data.questions)) {
+    return res.status(400).json({ error: 'Invalid assignment data' });
+  }
+  const assignment = createAssignment(data);
+  res.json(assignment);
+});
+
+app.get('/assignments/:id', authenticate, (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const assignment = assignments.find(a => a.id === id);
+  if (!assignment) return res.status(404).json({ error: 'Not found' });
+  res.json(assignment);
+});
+
+app.post('/templates', authenticate, authorize('Instructor'), (req, res) => {
+  const template = req.body;
+  if (!template.name || !Array.isArray(template.questions)) {
+    return res.status(400).json({ error: 'Invalid template data' });
+  }
+  templates.push(template);
+  res.json({ message: 'Template saved' });
+});
+
+app.get('/templates', authenticate, authorize('Instructor'), (req, res) => {
+  res.json(templates);
 });
 
 app.listen(3000, () => console.log('Server running on port 3000'));

--- a/frontend/assignments.html
+++ b/frontend/assignments.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Assignment Builder</title>
+  <style>
+    #questions, #selected { min-height: 150px; padding: 10px; border: 1px solid #ccc; }
+    .question { padding: 4px; border: 1px dashed #999; margin: 2px; cursor: move; }
+    .step { display: none; }
+    .step.active { display: block; }
+  </style>
+</head>
+<body>
+  <h1>Create Assignment</h1>
+  <div id="wizard">
+    <div class="step" id="step1">
+      <h2>Assignment Settings</h2>
+      <label>Title <input id="title" type="text"></label><br>
+      <label>Start Date <input id="start" type="datetime-local"></label><br>
+      <label>Due Date <input id="due" type="datetime-local"></label><br>
+      <label>Attempts <input id="attempts" type="number" min="1" value="1"></label><br>
+      <label>Time Limit (min) <input id="limit" type="number" min="0" value="0"></label><br>
+      <button id="next1">Next</button>
+    </div>
+    <div class="step" id="step2">
+      <h2>Select Questions</h2>
+      <div id="questions"></div>
+      <h3>Selected</h3>
+      <div id="selected"></div>
+      <button id="prev2">Back</button>
+      <button id="next2">Next</button>
+    </div>
+    <div class="step" id="step3">
+      <h2>Preview</h2>
+      <div id="preview"></div>
+      <button id="prev3">Back</button>
+      <button id="save">Save</button>
+    </div>
+  </div>
+
+  <script>
+    const steps = [document.getElementById('step1'), document.getElementById('step2'), document.getElementById('step3')];
+    let current = 0;
+    function showStep(i) { steps[current].classList.remove('active'); current = i; steps[current].classList.add('active'); }
+    showStep(0);
+
+    const approvedQuestions = [
+      { id: 1, text: 'What is 2+2?', topic: 'Math' },
+      { id: 2, text: 'Define gravity.', topic: 'Science' },
+      { id: 3, text: 'Who wrote Hamlet?', topic: 'Literature' }
+    ];
+    const questionsDiv = document.getElementById('questions');
+    const selectedDiv = document.getElementById('selected');
+
+    approvedQuestions.forEach(q => {
+      const div = document.createElement('div');
+      div.className = 'question';
+      div.textContent = `${q.topic}: ${q.text}`;
+      div.draggable = true;
+      div.dataset.id = q.id;
+      div.addEventListener('dragstart', e => e.dataTransfer.setData('id', q.id));
+      questionsDiv.appendChild(div);
+    });
+
+    ;[questionsDiv, selectedDiv].forEach(el => {
+      el.addEventListener('dragover', e => e.preventDefault());
+      el.addEventListener('drop', e => {
+        e.preventDefault();
+        const id = e.dataTransfer.getData('id');
+        const item = document.querySelector(`.question[data-id="${id}"]`);
+        el.appendChild(item);
+      });
+    });
+
+    document.getElementById('next1').onclick = () => showStep(1);
+    document.getElementById('prev2').onclick = () => showStep(0);
+    document.getElementById('next2').onclick = () => {
+      // build preview
+      const preview = document.getElementById('preview');
+      preview.innerHTML = '';
+      Array.from(selectedDiv.children).forEach((c, i) => {
+        const p = document.createElement('p');
+        p.textContent = `${i + 1}. ${c.textContent}`;
+        preview.appendChild(p);
+      });
+      showStep(2);
+    };
+    document.getElementById('prev3').onclick = () => showStep(1);
+
+    document.getElementById('save').onclick = async () => {
+      const data = {
+        title: document.getElementById('title').value,
+        startDate: document.getElementById('start').value,
+        dueDate: document.getElementById('due').value,
+        attempts: parseInt(document.getElementById('attempts').value, 10),
+        timeLimit: parseInt(document.getElementById('limit').value, 10),
+        questions: Array.from(selectedDiv.children).map(c => parseInt(c.dataset.id, 10)),
+      };
+      const token = localStorage.getItem('token');
+      const res = await fetch('/assignments', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + token,
+        },
+        body: JSON.stringify(data),
+      });
+      if (res.ok) {
+        alert('Assignment created');
+      } else {
+        alert('Error creating assignment');
+      }
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement in-memory assignments and templates backend
- expose `/assignments` and `/templates` endpoints
- add basic HTML assignment builder wizard with drag-and-drop
- document the new builder in README

## Testing
- `npm test`
- `cd backend && npm test`